### PR TITLE
#197 Sende meldingsdetaljer til Kafka

### DIFF
--- a/src/main/kotlin/no/nav/emottak/utils/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/config/KafkaConfig.kt
@@ -15,8 +15,12 @@ data class Kafka(
     val truststoreType: TruststoreType,
     val truststoreLocation: TruststoreLocation,
     val truststorePassword: Masked,
-    val groupId: String,
-    val topic: String,
+    val groupId: String
+)
+
+data class EventLogging(
+    val eventTopic: String,
+    val messageDetailsTopic: String,
     val eventLoggingProducerActive: Boolean
 )
 

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/client/EventPublisherClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/client/EventPublisherClient.kt
@@ -11,9 +11,9 @@ class EventPublisherClient(
 ) {
     private val kafkaPublisher = KafkaPublisher(config.toKafkaPublisherSettings())
 
-    suspend fun publishMessage(value: ByteArray): Result<RecordMetadata> =
+    suspend fun publishMessage(topic: String, value: ByteArray): Result<RecordMetadata> =
         kafkaPublisher.publishScope {
-            publishCatching(toProducerRecord(config.topic, value))
+            publishCatching(toProducerRecord(topic, value))
         }
 
     private fun toProducerRecord(topic: String, content: ByteArray): ProducerRecord<String, ByteArray> =

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetails.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetails.kt
@@ -27,7 +27,7 @@ data class EbmsMessageDetails(
     @Serializable(with = InstantSerializer::class)
     val sentAt: Instant? = null,
     @Serializable(with = InstantSerializer::class)
-    val savedAt: Instant? = ZonedDateTime.now(ZoneId.of("Europe/Oslo")).toInstant()
+    val savedAt: Instant = ZonedDateTime.now(ZoneId.of("Europe/Oslo")).toInstant()
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetails.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetails.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 import kotlin.uuid.Uuid
 
 @Serializable
-data class MessageDetails(
+data class EbmsMessageDetails(
     @Serializable(with = UuidSerializer::class)
     val requestId: Uuid,
     val cpaId: String,

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/MessageDetails.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/MessageDetails.kt
@@ -4,10 +4,12 @@ import kotlinx.serialization.Serializable
 import no.nav.emottak.utils.serialization.InstantSerializer
 import no.nav.emottak.utils.serialization.UuidSerializer
 import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import kotlin.uuid.Uuid
 
 @Serializable
-data class EventMessageDetails(
+data class MessageDetails(
     @Serializable(with = UuidSerializer::class)
     val requestId: Uuid,
     val cpaId: String,
@@ -23,7 +25,9 @@ data class EventMessageDetails(
     val refParam: String? = null,
     val sender: String? = null,
     @Serializable(with = InstantSerializer::class)
-    val sentAt: Instant? = null
+    val sentAt: Instant? = null,
+    @Serializable(with = InstantSerializer::class)
+    val savedAt: Instant? = ZonedDateTime.now(ZoneId.of("Europe/Oslo")).toInstant()
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/service/EventLoggingService.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/service/EventLoggingService.kt
@@ -2,8 +2,8 @@ package no.nav.emottak.utils.kafka.service
 
 import no.nav.emottak.utils.config.EventLogging
 import no.nav.emottak.utils.kafka.client.EventPublisherClient
+import no.nav.emottak.utils.kafka.model.EbmsMessageDetails
 import no.nav.emottak.utils.kafka.model.Event
-import no.nav.emottak.utils.kafka.model.MessageDetails
 import org.apache.kafka.clients.producer.RecordMetadata
 
 class EventLoggingService(
@@ -14,6 +14,6 @@ class EventLoggingService(
     suspend fun logEvent(event: Event): Result<RecordMetadata> =
         kafkaPublisherClient.publishMessage(eventLoggingConfig.eventTopic, event.toByteArray())
 
-    suspend fun logMessageDetails(messageDetails: MessageDetails): Result<RecordMetadata> =
-        kafkaPublisherClient.publishMessage(eventLoggingConfig.messageDetailsTopic, messageDetails.toByteArray())
+    suspend fun logMessageDetails(ebmsMessageDetails: EbmsMessageDetails): Result<RecordMetadata> =
+        kafkaPublisherClient.publishMessage(eventLoggingConfig.messageDetailsTopic, ebmsMessageDetails.toByteArray())
 }

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/service/EventLoggingService.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/service/EventLoggingService.kt
@@ -1,17 +1,19 @@
 package no.nav.emottak.utils.kafka.service
 
+import no.nav.emottak.utils.config.EventLogging
 import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.model.Event
-import no.nav.emottak.utils.kafka.model.EventMessageDetails
+import no.nav.emottak.utils.kafka.model.MessageDetails
 import org.apache.kafka.clients.producer.RecordMetadata
 
 class EventLoggingService(
+    private val eventLoggingConfig: EventLogging,
     private val kafkaPublisherClient: EventPublisherClient
 ) {
 
     suspend fun logEvent(event: Event): Result<RecordMetadata> =
-        kafkaPublisherClient.publishMessage(event.toByteArray())
+        kafkaPublisherClient.publishMessage(eventLoggingConfig.eventTopic, event.toByteArray())
 
-    suspend fun logEventMessageDetails(eventMessageDetails: EventMessageDetails): Result<RecordMetadata> =
-        kafkaPublisherClient.publishMessage(eventMessageDetails.toByteArray())
+    suspend fun logMessageDetails(messageDetails: MessageDetails): Result<RecordMetadata> =
+        kafkaPublisherClient.publishMessage(eventLoggingConfig.messageDetailsTopic, messageDetails.toByteArray())
 }

--- a/src/main/resources/kafka_common.conf
+++ b/src/main/resources/kafka_common.conf
@@ -8,6 +8,10 @@ kafka {
   truststoreType = "JKS"
   truststoreLocation = "${KAFKA_TRUSTSTORE_PATH:-}"
   truststorePassword = "${KAFKA_CREDSTORE_PASSWORD:-}"
-  topic = "team-emottak.event.log"
+}
+
+eventLogging {
+  eventTopic = "team-emottak.event.log"
+  messageDetailsTopic = "team-emottak.ebms.message.details"
   eventLoggingProducerActive = "${EVENT_LOGGING_PRODUCER:-false}"
 }

--- a/src/test/kotlin/no/nav/emottak/utils/kafka/client/EventPublisherClientSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/utils/kafka/client/EventPublisherClientSpec.kt
@@ -23,6 +23,7 @@ import kotlin.uuid.Uuid
 
 class EventPublisherClientSpec : KafkaSpec(
     {
+        val testTopic = "test-topic"
         lateinit var settings: Kafka
         lateinit var publisher: EventPublisherClient
 
@@ -36,9 +37,7 @@ class EventPublisherClientSpec : KafkaSpec(
                 truststoreType = TruststoreType(""),
                 truststoreLocation = TruststoreLocation(""),
                 truststorePassword = Masked(""),
-                groupId = "ebms-provider",
-                topic = "test-topic",
-                eventLoggingProducerActive = false
+                groupId = "ebms-provider"
             )
 
             settings = kafkaSettings()
@@ -50,11 +49,11 @@ class EventPublisherClientSpec : KafkaSpec(
                 val firstPublishedEvent = randomEvent("Event 1")
                 val lastPublishedEvent = randomEvent("Event 2")
 
-                publisher.publishMessage(firstPublishedEvent.toByteArray())
-                publisher.publishMessage(lastPublishedEvent.toByteArray())
+                publisher.publishMessage(testTopic, firstPublishedEvent.toByteArray())
+                publisher.publishMessage(testTopic, lastPublishedEvent.toByteArray())
 
                 val receiver = KafkaReceiver(receiverSettings())
-                val consumer = receiver.receive(settings.topic)
+                val consumer = receiver.receive(testTopic)
                     .map { Pair(it.key(), it.value()) }
 
                 consumer.test {
@@ -70,10 +69,10 @@ class EventPublisherClientSpec : KafkaSpec(
         "Publish one message to Kafka - message is received" {
             turbineScope {
                 val event = randomEvent("Event 3")
-                publisher.publishMessage(event.toByteArray())
+                publisher.publishMessage(testTopic, event.toByteArray())
 
                 val receiver = KafkaReceiver(receiverSettings())
-                val consumer = receiver.receive(settings.topic)
+                val consumer = receiver.receive(testTopic)
                     .map { Pair(it.key(), it.value()) }
 
                 consumer.test {


### PR DESCRIPTION
1. Utført utsending av meldingsdetaljer til en separat topic.
2. Lagt til `savedAt` feltet i `EbmsMessageDetails`.
3. Flyttet de innstillingene som gjelder hendelseloggingslogikken til en separat gruppe `EventLogging`.