### PR TITLE
Fikset standardverdier for felt til Event og EbmsMessageDetails

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.2.5"
+            version = "0.2.6"
             from(components["java"])
         }
     }

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetails.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetails.kt
@@ -6,6 +6,7 @@ import no.nav.emottak.utils.serialization.UuidSerializer
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 
 @Serializable
@@ -27,7 +28,10 @@ data class EbmsMessageDetails(
     @Serializable(with = InstantSerializer::class)
     val sentAt: Instant? = null,
     @Serializable(with = InstantSerializer::class)
-    val savedAt: Instant = ZonedDateTime.now(ZoneId.of("Europe/Oslo")).toInstant()
+    val savedAt: Instant = ZonedDateTime
+        .now(ZoneId.of("Europe/Oslo"))
+        .toInstant()
+        .truncatedTo(ChronoUnit.MICROS)
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
@@ -7,6 +7,7 @@ import no.nav.emottak.utils.serialization.UuidSerializer
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 
 @Serializable
@@ -16,9 +17,12 @@ data class Event(
     val requestId: Uuid,
     val contentId: String? = null,
     val messageId: String,
-    val eventData: String? = null,
+    val eventData: String? = "{}",
     @Serializable(with = InstantSerializer::class)
-    val createdAt: Instant = ZonedDateTime.now(ZoneId.of("Europe/Oslo")).toInstant()
+    val createdAt: Instant = ZonedDateTime
+        .now(ZoneId.of("Europe/Oslo"))
+        .toInstant()
+        .truncatedTo(ChronoUnit.MICROS)
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
@@ -17,7 +17,7 @@ data class Event(
     val requestId: Uuid,
     val contentId: String? = null,
     val messageId: String,
-    val eventData: String? = "{}",
+    val eventData: String = "{}",
     @Serializable(with = InstantSerializer::class)
     val createdAt: Instant = ZonedDateTime
         .now(ZoneId.of("Europe/Oslo"))


### PR DESCRIPTION
Ny standardverdi for `Event.eventData` er `"{}"` fordi det er serialisert objekt.
Ny standardverdi for `Event.createdAt` og `EbmsMessageDetails.savedAt` er begrenset med mikrosekunder fordi det er den største presisjon støttet med database. 