### PR TITLE
261 edi adapter klient

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.6"
+            version = "0.3.5.dev10"
             from(components["java"])
         }
     }
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.sqldelight.primitive.adapters)
     implementation(libs.bundles.ktor)
+    implementation(libs.nimbus.jwt)
     api(libs.vault.java.driver)
 
     testImplementation(kotlin("test"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev7"
+            version = "0.3.6"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev14"
+            version = "0.3.5.dev15"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev4"
+            version = "0.3.5.dev5"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev5"
+            version = "0.3.5.dev6"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     implementation(libs.arrow.fx.coroutines)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.sqldelight.primitive.adapters)
+    implementation(libs.ktor.client.core)
     api(libs.vault.java.driver)
+
     testImplementation(kotlin("test"))
     testImplementation(testLibs.bundles.kotest)
     testImplementation(testLibs.kotest.extensions.testcontainers)
@@ -56,7 +58,6 @@ dependencies {
     testImplementation(testLibs.testcontainers)
     testImplementation(testLibs.testcontainers.kafka)
     testImplementation(testLibs.turbine)
-
     testImplementation("org.eclipse.jetty:jetty-server:11.0.25")
     testImplementation("commons-io:commons-io:2.18.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev3"
+            version = "0.3.5.dev4"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev11"
+            version = "0.3.5.dev12"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev12"
+            version = "0.3.5.dev13"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev2"
+            version = "0.3.5.dev3"
             from(components["java"])
         }
     }
@@ -48,7 +48,7 @@ dependencies {
     implementation(libs.arrow.fx.coroutines)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.sqldelight.primitive.adapters)
-    implementation(libs.ktor.client.core)
+    implementation(libs.bundles.ktor)
     api(libs.vault.java.driver)
 
     testImplementation(kotlin("test"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5"
+            version = "0.3.5.dev1"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev1"
+            version = "0.3.5.dev2"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev6"
+            version = "0.3.5.dev7"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev10"
+            version = "0.3.5.dev11"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5.dev13"
+            version = "0.3.5.dev14"
             from(components["java"])
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
             version("sqldelight-primitive-adapters", "2.0.2")
             version("vault", "5.1.0")
             version("ktor", "3.1.2")
+            version("nimbus", "10.0.1")
 
             library("slf4j", "org.slf4j", "slf4j-api").versionRef("slf4j")
             library("hoplite-core", "com.sksamuel.hoplite", "hoplite-core").versionRef("hoplite")
@@ -23,8 +24,10 @@ dependencyResolutionManagement {
             library("ktor-client-cio", "io.ktor", "ktor-client-cio").versionRef("ktor")
             library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
             library("ktor-serialization-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef("ktor")
+            library("ktor-client-auth", "io.ktor", "ktor-client-auth").versionRef("ktor")
+            library("nimbus-jwt", "com.nimbusds", "nimbus-jose-jwt").versionRef("nimbus")
 
-            bundle("ktor", listOf("ktor-client-core", "ktor-client-cio", "ktor-client-content-negotiation", "ktor-serialization-json"))
+            bundle("ktor", listOf("ktor-client-core", "ktor-client-cio", "ktor-client-content-negotiation", "ktor-serialization-json", "ktor-client-auth"))
         }
 
         create("testLibs") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,11 @@ dependencyResolutionManagement {
             library("sqldelight-primitive-adapters", "app.cash.sqldelight", "primitive-adapters").versionRef("sqldelight-primitive-adapters")
             library("vault-java-driver", "com.bettercloud", "vault-java-driver").versionRef("vault")
             library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
+            library("ktor-client-cio", "io.ktor", "ktor-client-cio").versionRef("ktor")
+            library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
+            library("ktor-serialization-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef("ktor")
+
+            bundle("ktor", listOf("ktor-client-core", "ktor-client-cio", "ktor-client-content-negotiation", "ktor-serialization-json"))
         }
 
         create("testLibs") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
             version("kotlinx-serialization", "1.8.0")
             version("sqldelight-primitive-adapters", "2.0.2")
             version("vault", "5.1.0")
+            version("ktor", "3.1.2")
 
             library("slf4j", "org.slf4j", "slf4j-api").versionRef("slf4j")
             library("hoplite-core", "com.sksamuel.hoplite", "hoplite-core").versionRef("hoplite")
@@ -18,6 +19,7 @@ dependencyResolutionManagement {
             library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlinx-serialization")
             library("sqldelight-primitive-adapters", "app.cash.sqldelight", "primitive-adapters").versionRef("sqldelight-primitive-adapters")
             library("vault-java-driver", "com.bettercloud", "vault-java-driver").versionRef("vault")
+            library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
         }
 
         create("testLibs") {

--- a/src/main/kotlin/no/nav/emottak/utils/common/ScopedAuthHttpClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/common/ScopedAuthHttpClient.kt
@@ -1,4 +1,4 @@
-package no.nav.emottak.utils.edi2
+package no.nav.emottak.utils.common
 
 import com.nimbusds.jwt.SignedJWT
 import io.ktor.client.HttpClient

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -2,6 +2,8 @@ package no.nav.emottak.utils.edi2
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
@@ -10,6 +12,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
 import no.nav.emottak.utils.edi2.models.ApprecInfo
 import no.nav.emottak.utils.edi2.models.ErrorMessage
 import no.nav.emottak.utils.edi2.models.GetBusinessDocumentResponse
@@ -22,8 +25,14 @@ import no.nav.emottak.utils.environment.getEnvVar
 import kotlin.uuid.Uuid
 
 class EdiAdapterClient(clientProvider: () -> HttpClient) {
-    private var httpClient = clientProvider.invoke()
     private val ediAdapterUrl = getEnvVar("EDI_ADAPTER_URL", "http://edi-adapter")
+
+    private var httpClient = HttpClient(CIO) {
+        expectSuccess = true
+        install(ContentNegotiation) {
+            json()
+        }
+    }
 
     suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
         val response = httpClient.get("$ediAdapterUrl/api/messages/$id/apprec") {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -21,12 +21,9 @@ import no.nav.emottak.utils.edi2.models.Message
 import no.nav.emottak.utils.edi2.models.PostAppRecRequest
 import no.nav.emottak.utils.edi2.models.PostMessageRequest
 import no.nav.emottak.utils.edi2.models.StatusInfo
-import no.nav.emottak.utils.environment.getEnvVar
 import kotlin.uuid.Uuid
 
-class EdiAdapterClient(clientProvider: () -> HttpClient) {
-    private val ediAdapterUrl = getEnvVar("EDI_ADAPTER_URL", "http://edi-adapter")
-
+class EdiAdapterClient(private val ediAdapterUrl: String) {
     private var httpClient = HttpClient(CIO) {
         expectSuccess = true
         install(ContentNegotiation) {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -45,7 +45,7 @@ class EdiAdapterClient(private val ediAdapterUrl: String) {
         return handleResponse(response)
     }
 
-    suspend fun postMessages(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
+    suspend fun postMessage(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
         val response = httpClient.post("$ediAdapterUrl/api/v1/messages") {
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -32,21 +32,21 @@ class EdiAdapterClient(private val ediAdapterUrl: String) {
     }
 
     suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/messages/$id/apprec") {
+        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/apprec") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Pair<List<Message>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/messages?${getMessagesRequest.toUrlParams()}") {
+        val response = httpClient.get("$ediAdapterUrl/api/v1/messages?${getMessagesRequest.toUrlParams()}") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun postMessages(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
-        val response = httpClient.post("$ediAdapterUrl/api/messages") {
+        val response = httpClient.post("$ediAdapterUrl/api/v1/messages") {
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)
         }
@@ -54,28 +54,28 @@ class EdiAdapterClient(private val ediAdapterUrl: String) {
     }
 
     suspend fun getMessage(id: Uuid): Pair<Message?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/messages/$id") {
+        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun getBusinessDocument(id: Uuid): Pair<GetBusinessDocumentResponse?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/messages/$id/business-document") {
+        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/document") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun getMessageStatus(id: Uuid): Pair<List<StatusInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/messages/$id/status") {
+        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/status") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun postApprec(id: Uuid, apprecSenderHerId: Int, postAppRecRequest: PostAppRecRequest): Pair<String?, ErrorMessage?> {
-        val response = httpClient.post("$ediAdapterUrl/api/messages/$id/apprec/$apprecSenderHerId") {
+        val response = httpClient.post("$ediAdapterUrl/api/v1/messages/$id/apprec/$apprecSenderHerId") {
             contentType(ContentType.Application.Json)
             setBody(postAppRecRequest)
         }
@@ -83,7 +83,7 @@ class EdiAdapterClient(private val ediAdapterUrl: String) {
     }
 
     suspend fun markMessageAsRead(id: Uuid, herId: Int): Pair<Boolean?, ErrorMessage?> {
-        val response = httpClient.put("$ediAdapterUrl/api/messages/$id/read/$herId") {
+        val response = httpClient.put("$ediAdapterUrl/api/v1/messages/$id/read/$herId") {
             contentType(ContentType.Application.Json)
         }
         return if (response.status == HttpStatusCode.NoContent) {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -33,7 +34,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from getApprecInfo: $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -43,7 +44,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from getMessages(): $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -54,7 +55,7 @@ class EdiAdapterClient(
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from postMessage() : $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -64,7 +65,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from getMessage() : $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -74,7 +75,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from getBusinessDocument() : $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -84,7 +85,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from getMessageStatus() : $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -95,7 +96,7 @@ class EdiAdapterClient(
             contentType(ContentType.Application.Json)
             setBody(postAppRecRequest)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from postApprec() : $url : ${response.bodyAsText()}")
 
         return handleResponse(response)
     }
@@ -105,7 +106,7 @@ class EdiAdapterClient(
         val response = httpClient.put(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from $url : $response")
+        log.debug("EDI2 test: Response from markMessageAsRead() : $url : ${response.bodyAsText()}")
 
         return if (response.status == HttpStatusCode.NoContent) {
             Pair(true, null)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -116,10 +116,12 @@ class EdiAdapterClient(
     }
 
     private suspend inline fun <reified T> handleResponse(httpResponse: HttpResponse): Pair<T?, ErrorMessage?> {
-        return if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
+        val result: Pair<T?, ErrorMessage?> =  if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
             Pair(httpResponse.body(), null)
         } else {
             Pair(null, httpResponse.body())
         }
+        log.debug("EDI2 test: handleResponse result: $result")
+        return result
     }
 }

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -1,0 +1,41 @@
+package no.nav.emottak.utils.edi2
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.nav.emottak.utils.edi2.models.ApprecInfo
+import no.nav.emottak.utils.edi2.models.ErrorMessage
+import no.nav.emottak.utils.edi2.models.GetMessagesRequest
+import no.nav.emottak.utils.environment.getEnvVar
+import kotlin.uuid.Uuid
+
+class EdiAdapterClient(clientProvider: () -> HttpClient) {
+    private var httpClient = clientProvider.invoke()
+    private val ediAdapterUrl = getEnvVar("EDI_ADAPTER_URL", "http://emottak-edi-adapter")
+
+    suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
+        val response = httpClient.get("$ediAdapterUrl/Messages/$id/apprec") {
+            contentType(ContentType.Application.Json)
+        }
+        return handleResponse(response)
+    }
+
+    suspend fun getMessages(request: GetMessagesRequest): Pair<List<ApprecInfo>?, ErrorMessage?> {
+        val response = httpClient.get("$ediAdapterUrl/Messages?${request.toUrlParams()}") {
+            contentType(ContentType.Application.Json)
+        }
+        return handleResponse(response)
+    }
+
+    private suspend inline fun <reified T> handleResponse(httpResponse: HttpResponse): Pair<T?, ErrorMessage?> {
+        return if (httpResponse.status == HttpStatusCode.OK) {
+            Pair(httpResponse.body(), null)
+        } else {
+            Pair(null, httpResponse.body())
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -7,7 +7,6 @@ import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -19,13 +18,11 @@ import no.nav.emottak.utils.edi2.models.Message
 import no.nav.emottak.utils.edi2.models.PostAppRecRequest
 import no.nav.emottak.utils.edi2.models.PostMessageRequest
 import no.nav.emottak.utils.edi2.models.StatusInfo
-import org.slf4j.Logger
 import kotlin.uuid.Uuid
 
 class EdiAdapterClient(
     private val ediAdapterUrl: String,
-    private val clientProvider: () -> HttpClient,
-    private val log: Logger
+    clientProvider: () -> HttpClient
 ) {
     private var httpClient = clientProvider.invoke()
 
@@ -34,11 +31,8 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.info("EDI2 test: Response from getApprecInfo: $url : ${response.bodyAsText()}, status: ${response.status}")
 
-        val result: Pair<List<ApprecInfo>?, ErrorMessage?> = handleResponse(response)
-        log.info("EDI2 test: getApprecInfo() method returns $result")
-        return result
+        return handleResponse(response)
     }
 
     suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Pair<List<Message>?, ErrorMessage?> {
@@ -46,11 +40,8 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.info("EDI2 test: Response from getMessages(): $url : ${response.bodyAsText()} , status: ${response.status}")
 
-        val result: Pair<List<Message>?, ErrorMessage?> = handleResponse(response)
-        log.info("EDI2 test: getMessages() method returns $result")
-        return result
+        return handleResponse(response)
     }
 
     suspend fun postMessage(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
@@ -59,7 +50,6 @@ class EdiAdapterClient(
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)
         }
-        log.info("EDI2 test: Response from postMessage() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -69,11 +59,8 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.info("EDI2 test: Response from getMessage() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
-        val result: Pair<Message?, ErrorMessage?> = handleResponse(response)
-        log.info("EDI2 test: getMessage() method returns $result")
-        return result
+        return handleResponse(response)
     }
 
     suspend fun getBusinessDocument(id: Uuid): Pair<GetBusinessDocumentResponse?, ErrorMessage?> {
@@ -81,7 +68,6 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.info("EDI2 test: Response from getBusinessDocument() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -91,7 +77,6 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.info("EDI2 test: Response from getMessageStatus() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -102,7 +87,6 @@ class EdiAdapterClient(
             contentType(ContentType.Application.Json)
             setBody(postAppRecRequest)
         }
-        log.info("EDI2 test: Response from postApprec() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -112,7 +96,6 @@ class EdiAdapterClient(
         val response = httpClient.put(url) {
             contentType(ContentType.Application.Json)
         }
-        log.info("EDI2 test: Response from markMessageAsRead() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return if (response.status == HttpStatusCode.NoContent) {
             Pair(true, null)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -2,8 +2,6 @@ package no.nav.emottak.utils.edi2
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
@@ -12,7 +10,6 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
 import no.nav.emottak.utils.edi2.models.ApprecInfo
 import no.nav.emottak.utils.edi2.models.ErrorMessage
 import no.nav.emottak.utils.edi2.models.GetBusinessDocumentResponse
@@ -23,13 +20,8 @@ import no.nav.emottak.utils.edi2.models.PostMessageRequest
 import no.nav.emottak.utils.edi2.models.StatusInfo
 import kotlin.uuid.Uuid
 
-class EdiAdapterClient(private val ediAdapterUrl: String) {
-    private var httpClient = HttpClient(CIO) {
-        expectSuccess = true
-        install(ContentNegotiation) {
-            json()
-        }
-    }
+class EdiAdapterClient(private val ediAdapterUrl: String, clientProvider: () -> HttpClient) {
+    private var httpClient = clientProvider.invoke()
 
     suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
         val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/apprec") {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -18,66 +18,95 @@ import no.nav.emottak.utils.edi2.models.Message
 import no.nav.emottak.utils.edi2.models.PostAppRecRequest
 import no.nav.emottak.utils.edi2.models.PostMessageRequest
 import no.nav.emottak.utils.edi2.models.StatusInfo
+import org.slf4j.Logger
 import kotlin.uuid.Uuid
 
-class EdiAdapterClient(private val ediAdapterUrl: String, clientProvider: () -> HttpClient) {
+class EdiAdapterClient(
+    private val ediAdapterUrl: String,
+    private val clientProvider: () -> HttpClient,
+    private val log: Logger
+) {
     private var httpClient = clientProvider.invoke()
 
     suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/apprec") {
+        val url = "$ediAdapterUrl/api/v1/messages/$id/apprec"
+        val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Pair<List<Message>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/v1/messages?${getMessagesRequest.toUrlParams()}") {
+        val url = "$ediAdapterUrl/api/v1/messages?${getMessagesRequest.toUrlParams()}"
+        val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun postMessage(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
-        val response = httpClient.post("$ediAdapterUrl/api/v1/messages") {
+        val url = "$ediAdapterUrl/api/v1/messages"
+        val response = httpClient.post(url) {
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun getMessage(id: Uuid): Pair<Message?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id") {
+        val url = "$ediAdapterUrl/api/v1/messages/$id"
+        val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun getBusinessDocument(id: Uuid): Pair<GetBusinessDocumentResponse?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/document") {
+        val url = "$ediAdapterUrl/api/v1/messages/$id/document"
+        val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun getMessageStatus(id: Uuid): Pair<List<StatusInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/api/v1/messages/$id/status") {
+        val url = "$ediAdapterUrl/api/v1/messages/$id/status"
+        val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun postApprec(id: Uuid, apprecSenderHerId: Int, postAppRecRequest: PostAppRecRequest): Pair<String?, ErrorMessage?> {
-        val response = httpClient.post("$ediAdapterUrl/api/v1/messages/$id/apprec/$apprecSenderHerId") {
+        val url = "$ediAdapterUrl/api/v1/messages/$id/apprec/$apprecSenderHerId"
+        val response = httpClient.post(url) {
             contentType(ContentType.Application.Json)
             setBody(postAppRecRequest)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return handleResponse(response)
     }
 
     suspend fun markMessageAsRead(id: Uuid, herId: Int): Pair<Boolean?, ErrorMessage?> {
-        val response = httpClient.put("$ediAdapterUrl/api/v1/messages/$id/read/$herId") {
+        val url = "$ediAdapterUrl/api/v1/messages/$id/read/$herId"
+        val response = httpClient.put(url) {
             contentType(ContentType.Application.Json)
         }
+        log.debug("EDI2 test: Response from $url : $response")
+
         return if (response.status == HttpStatusCode.NoContent) {
             Pair(true, null)
         } else {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -34,9 +34,11 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from getApprecInfo: $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from getApprecInfo: $url : ${response.bodyAsText()}, status: ${response.status}")
 
-        return handleResponse(response)
+        val result: Pair<List<ApprecInfo>?, ErrorMessage?> = handleResponse(response)
+        log.info("EDI2 test: getApprecInfo() method returns $result")
+        return result
     }
 
     suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Pair<List<Message>?, ErrorMessage?> {
@@ -44,9 +46,11 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from getMessages(): $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from getMessages(): $url : ${response.bodyAsText()} , status: ${response.status}")
 
-        return handleResponse(response)
+        val result: Pair<List<Message>?, ErrorMessage?> = handleResponse(response)
+        log.info("EDI2 test: getMessages() method returns $result")
+        return result
     }
 
     suspend fun postMessage(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
@@ -55,7 +59,7 @@ class EdiAdapterClient(
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)
         }
-        log.debug("EDI2 test: Response from postMessage() : $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from postMessage() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -65,9 +69,11 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from getMessage() : $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from getMessage() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
-        return handleResponse(response)
+        val result: Pair<Message?, ErrorMessage?> = handleResponse(response)
+        log.info("EDI2 test: getMessage() method returns $result")
+        return result
     }
 
     suspend fun getBusinessDocument(id: Uuid): Pair<GetBusinessDocumentResponse?, ErrorMessage?> {
@@ -75,7 +81,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from getBusinessDocument() : $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from getBusinessDocument() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -85,7 +91,7 @@ class EdiAdapterClient(
         val response = httpClient.get(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from getMessageStatus() : $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from getMessageStatus() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -96,7 +102,7 @@ class EdiAdapterClient(
             contentType(ContentType.Application.Json)
             setBody(postAppRecRequest)
         }
-        log.debug("EDI2 test: Response from postApprec() : $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from postApprec() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return handleResponse(response)
     }
@@ -106,7 +112,7 @@ class EdiAdapterClient(
         val response = httpClient.put(url) {
             contentType(ContentType.Application.Json)
         }
-        log.debug("EDI2 test: Response from markMessageAsRead() : $url : ${response.bodyAsText()}")
+        log.info("EDI2 test: Response from markMessageAsRead() : $url : ${response.bodyAsText()}, status: ${response.status}")
 
         return if (response.status == HttpStatusCode.NoContent) {
             Pair(true, null)
@@ -116,12 +122,10 @@ class EdiAdapterClient(
     }
 
     private suspend inline fun <reified T> handleResponse(httpResponse: HttpResponse): Pair<T?, ErrorMessage?> {
-        val result: Pair<T?, ErrorMessage?> = if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
+        return if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
             Pair(httpResponse.body(), null)
         } else {
             Pair(null, httpResponse.body())
         }
-        log.debug("EDI2 test: handleResponse result: $result")
-        return result
     }
 }

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -23,24 +23,24 @@ import kotlin.uuid.Uuid
 
 class EdiAdapterClient(clientProvider: () -> HttpClient) {
     private var httpClient = clientProvider.invoke()
-    private val ediAdapterUrl = getEnvVar("EDI_ADAPTER_URL", "http://emottak-edi-adapter")
+    private val ediAdapterUrl = getEnvVar("EDI_ADAPTER_URL", "http://edi-adapter")
 
     suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/messages/$id/apprec") {
+        val response = httpClient.get("$ediAdapterUrl/api/messages/$id/apprec") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Pair<List<Message>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/messages?${getMessagesRequest.toUrlParams()}") {
+        val response = httpClient.get("$ediAdapterUrl/api/messages?${getMessagesRequest.toUrlParams()}") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun postMessages(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
-        val response = httpClient.post("$ediAdapterUrl/messages") {
+        val response = httpClient.post("$ediAdapterUrl/api/messages") {
             contentType(ContentType.Application.Json)
             setBody(postMessagesRequest)
         }
@@ -48,36 +48,36 @@ class EdiAdapterClient(clientProvider: () -> HttpClient) {
     }
 
     suspend fun getMessage(id: Uuid): Pair<Message?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/messages/$id") {
+        val response = httpClient.get("$ediAdapterUrl/api/messages/$id") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun getBusinessDocument(id: Uuid): Pair<GetBusinessDocumentResponse?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/messages/$id/business-document") {
+        val response = httpClient.get("$ediAdapterUrl/api/messages/$id/business-document") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
     suspend fun getMessageStatus(id: Uuid): Pair<List<StatusInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/messages/$id/status") {
+        val response = httpClient.get("$ediAdapterUrl/api/messages/$id/status") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
-    suspend fun postApprec(id: Uuid, apprecSenderHerId: Int, postMessageRequest: PostAppRecRequest): Pair<String?, ErrorMessage?> {
-        val response = httpClient.post("$ediAdapterUrl/messages/$id/apprec/$apprecSenderHerId") {
+    suspend fun postApprec(id: Uuid, apprecSenderHerId: Int, postAppRecRequest: PostAppRecRequest): Pair<String?, ErrorMessage?> {
+        val response = httpClient.post("$ediAdapterUrl/api/messages/$id/apprec/$apprecSenderHerId") {
             contentType(ContentType.Application.Json)
-            setBody(postMessageRequest)
+            setBody(postAppRecRequest)
         }
         return handleResponse(response)
     }
 
     suspend fun markMessageAsRead(id: Uuid, herId: Int): Pair<Boolean?, ErrorMessage?> {
-        val response = httpClient.put("$ediAdapterUrl/messages/$id/read/$herId") {
+        val response = httpClient.put("$ediAdapterUrl/api/messages/$id/read/$herId") {
             contentType(ContentType.Application.Json)
         }
         return if (response.status == HttpStatusCode.NoContent) {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -116,7 +116,7 @@ class EdiAdapterClient(
     }
 
     private suspend inline fun <reified T> handleResponse(httpResponse: HttpResponse): Pair<T?, ErrorMessage?> {
-        val result: Pair<T?, ErrorMessage?> =  if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
+        val result: Pair<T?, ErrorMessage?> = if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
             Pair(httpResponse.body(), null)
         } else {
             Pair(null, httpResponse.body())

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/EdiAdapterClient.kt
@@ -3,13 +3,21 @@ package no.nav.emottak.utils.edi2
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import no.nav.emottak.utils.edi2.models.ApprecInfo
 import no.nav.emottak.utils.edi2.models.ErrorMessage
+import no.nav.emottak.utils.edi2.models.GetBusinessDocumentResponse
 import no.nav.emottak.utils.edi2.models.GetMessagesRequest
+import no.nav.emottak.utils.edi2.models.Message
+import no.nav.emottak.utils.edi2.models.PostAppRecRequest
+import no.nav.emottak.utils.edi2.models.PostMessageRequest
+import no.nav.emottak.utils.edi2.models.StatusInfo
 import no.nav.emottak.utils.environment.getEnvVar
 import kotlin.uuid.Uuid
 
@@ -18,21 +26,69 @@ class EdiAdapterClient(clientProvider: () -> HttpClient) {
     private val ediAdapterUrl = getEnvVar("EDI_ADAPTER_URL", "http://emottak-edi-adapter")
 
     suspend fun getApprecInfo(id: Uuid): Pair<List<ApprecInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/Messages/$id/apprec") {
+        val response = httpClient.get("$ediAdapterUrl/messages/$id/apprec") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
     }
 
-    suspend fun getMessages(request: GetMessagesRequest): Pair<List<ApprecInfo>?, ErrorMessage?> {
-        val response = httpClient.get("$ediAdapterUrl/Messages?${request.toUrlParams()}") {
+    suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Pair<List<Message>?, ErrorMessage?> {
+        val response = httpClient.get("$ediAdapterUrl/messages?${getMessagesRequest.toUrlParams()}") {
             contentType(ContentType.Application.Json)
         }
         return handleResponse(response)
+    }
+
+    suspend fun postMessages(postMessagesRequest: PostMessageRequest): Pair<String?, ErrorMessage?> {
+        val response = httpClient.post("$ediAdapterUrl/messages") {
+            contentType(ContentType.Application.Json)
+            setBody(postMessagesRequest)
+        }
+        return handleResponse(response)
+    }
+
+    suspend fun getMessage(id: Uuid): Pair<Message?, ErrorMessage?> {
+        val response = httpClient.get("$ediAdapterUrl/messages/$id") {
+            contentType(ContentType.Application.Json)
+        }
+        return handleResponse(response)
+    }
+
+    suspend fun getBusinessDocument(id: Uuid): Pair<GetBusinessDocumentResponse?, ErrorMessage?> {
+        val response = httpClient.get("$ediAdapterUrl/messages/$id/business-document") {
+            contentType(ContentType.Application.Json)
+        }
+        return handleResponse(response)
+    }
+
+    suspend fun getMessageStatus(id: Uuid): Pair<List<StatusInfo>?, ErrorMessage?> {
+        val response = httpClient.get("$ediAdapterUrl/messages/$id/status") {
+            contentType(ContentType.Application.Json)
+        }
+        return handleResponse(response)
+    }
+
+    suspend fun postApprec(id: Uuid, apprecSenderHerId: Int, postMessageRequest: PostAppRecRequest): Pair<String?, ErrorMessage?> {
+        val response = httpClient.post("$ediAdapterUrl/messages/$id/apprec/$apprecSenderHerId") {
+            contentType(ContentType.Application.Json)
+            setBody(postMessageRequest)
+        }
+        return handleResponse(response)
+    }
+
+    suspend fun markMessageAsRead(id: Uuid, herId: Int): Pair<Boolean?, ErrorMessage?> {
+        val response = httpClient.put("$ediAdapterUrl/messages/$id/read/$herId") {
+            contentType(ContentType.Application.Json)
+        }
+        return if (response.status == HttpStatusCode.NoContent) {
+            Pair(true, null)
+        } else {
+            Pair(null, response.body())
+        }
     }
 
     private suspend inline fun <reified T> handleResponse(httpResponse: HttpResponse): Pair<T?, ErrorMessage?> {
-        return if (httpResponse.status == HttpStatusCode.OK) {
+        return if (httpResponse.status == HttpStatusCode.OK || httpResponse.status == HttpStatusCode.Created) {
             Pair(httpResponse.body(), null)
         } else {
             Pair(null, httpResponse.body())

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/ScopedAuthHttpClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/ScopedAuthHttpClient.kt
@@ -1,0 +1,84 @@
+package no.nav.emottak.utils.edi2
+
+import com.nimbusds.jwt.SignedJWT
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.header
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import no.nav.emottak.utils.environment.getEnvVar
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URI
+
+fun scopedAuthHttpClient(
+    scope: String
+): () -> HttpClient {
+    return {
+        HttpClient(CIO) {
+            expectSuccess = true
+            install(ContentNegotiation) {
+                json()
+            }
+            install(Auth) {
+                bearer {
+                    refreshTokens {
+                        proxiedHttpClient().post(
+                            getEnvVar(
+                                "AZURE_OPENID_CONFIG_TOKEN_ENDPOINT",
+                                "http://localhost:3344/AZURE_AD/token"
+                            )
+                        ) {
+                            headers {
+                                header("Content-Type", "application/x-www-form-urlencoded")
+                            }
+                            setBody(
+                                "client_id=" + getEnvVar("AZURE_APP_CLIENT_ID", "dummyclient") +
+                                    "&client_secret=" + getEnvVar("AZURE_APP_CLIENT_SECRET", "dummysecret") +
+                                    "&scope=" + scope +
+                                    "&grant_type=client_credentials"
+                            )
+                        }.bodyAsText()
+                            .let { tokenResponseString ->
+                                // log.info("The token response string we received was: $tokenResponseString")
+                                SignedJWT.parse(
+                                    LENIENT_JSON_PARSER.decodeFromString<Map<String, String>>(tokenResponseString)["access_token"] as String
+                                )
+                            }
+                            .let { parsedJwt ->
+                                // log.info("After parsing it, we got: $parsedJwt")
+                                BearerTokens(parsedJwt.serialize(), "refresh token is unused")
+                            }
+                    }
+                    sendWithoutRequest {
+                        true
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun proxiedHttpClient() = HttpClient(CIO) {
+    engine {
+        val httpProxyUrl = getEnvVar("HTTP_PROXY", "")
+        if (httpProxyUrl.isNotBlank()) {
+            proxy = Proxy(
+                Proxy.Type.HTTP,
+                InetSocketAddress(URI(httpProxyUrl).toURL().host, URI(httpProxyUrl).toURL().port)
+            )
+        }
+    }
+}
+
+val LENIENT_JSON_PARSER = Json {
+    isLenient = true
+}

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/ScopedAuthHttpClient.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/ScopedAuthHttpClient.kt
@@ -24,9 +24,12 @@ fun scopedAuthHttpClient(
 ): () -> HttpClient {
     return {
         HttpClient(CIO) {
-            expectSuccess = true
             install(ContentNegotiation) {
-                json()
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                    }
+                )
             }
             install(Auth) {
                 bearer {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecError.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecError.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class AppRecError(
-    val errorCode: String?,
-    val details: String?,
-    val description: String?,
-    val oid: String?
+    val errorCode: String? = null,
+    val details: String? = null,
+    val description: String? = null,
+    val oid: String? = null
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecError.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecError.kt
@@ -1,0 +1,11 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppRecError(
+    val errorCode: String?,
+    val details: String?,
+    val description: String?,
+    val oid: String?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecStatus.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecStatus.kt
@@ -1,8 +1,14 @@
 package no.nav.emottak.utils.edi2.models
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Serializable
+@Serializable(with = AppRecStatusSerializer::class)
 enum class AppRecStatus(val value: String, val description: String) {
     OK("Ok", "Ok"),
     REJECTED("Rejected", "Avvist"),
@@ -12,5 +18,34 @@ enum class AppRecStatus(val value: String, val description: String) {
     companion object {
         fun fromValue(value: String?): AppRecStatus =
             entries.find { it.value.equals(value, ignoreCase = true) } ?: UNKNOWN
+    }
+}
+
+object AppRecStatusSerializer : KSerializer<AppRecStatus> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("AppRecStatus", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: AppRecStatus) {
+        val code = when (value) {
+            AppRecStatus.OK -> "1"
+            AppRecStatus.REJECTED -> "2"
+            AppRecStatus.OK_ERROR_IN_MESSAGE_PART -> "3"
+            AppRecStatus.UNKNOWN -> "4"
+        }
+        encoder.encodeString(code)
+    }
+
+    override fun deserialize(decoder: Decoder): AppRecStatus {
+        return when (decoder.decodeString()) {
+            "1" -> AppRecStatus.OK
+            AppRecStatus.OK.value -> AppRecStatus.OK
+            "2" -> AppRecStatus.REJECTED
+            AppRecStatus.REJECTED.value -> AppRecStatus.REJECTED
+            "3" -> AppRecStatus.OK_ERROR_IN_MESSAGE_PART
+            AppRecStatus.OK_ERROR_IN_MESSAGE_PART.value -> AppRecStatus.OK_ERROR_IN_MESSAGE_PART
+            "4" -> AppRecStatus.UNKNOWN
+            AppRecStatus.UNKNOWN.value -> AppRecStatus.UNKNOWN
+            else -> AppRecStatus.UNKNOWN
+        }
     }
 }

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecStatus.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/AppRecStatus.kt
@@ -1,0 +1,16 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class AppRecStatus(val value: String, val description: String) {
+    OK("Ok", "Ok"),
+    REJECTED("Rejected", "Avvist"),
+    OK_ERROR_IN_MESSAGE_PART("OkErrorInMessagePart", "Ok, feil i delmelding"),
+    UNKNOWN("Unknown", "The value is not supported");
+
+    companion object {
+        fun fromValue(value: String?): AppRecStatus =
+            entries.find { it.value.equals(value, ignoreCase = true) } ?: UNKNOWN
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/ApprecInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/ApprecInfo.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ApprecInfo(
     val receiverHerId: Int,
-    val appRecStatus: AppRecStatus?,
-    val appRecErrorList: List<AppRecError>?
+    val appRecStatus: AppRecStatus? = null,
+    val appRecErrorList: List<AppRecError>? = null
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/ApprecInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/ApprecInfo.kt
@@ -1,0 +1,10 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ApprecInfo(
+    val receiverHerId: Int,
+    val appRecStatus: AppRecStatus?,
+    val appRecErrorList: List<AppRecError>?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/DeliveryState.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/DeliveryState.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 enum class DeliveryState(val value: String, val description: String) {
     UNCONFIRMED("Unconfirmed", "Transport is not confirmed"),
     ACKNOWLEDGED("Acknowledged", "Transport is confirmed. Equivalent to 'Acknowledgement' without severe 'eb:ErrorList/eb:HighestSeverity'"),
-    REJECTED("Rejected", "Transport is rejected. Equivalient to 'MessageError' with 'eb:ErrorList/eb:HighestSeverity'=\"Error\""),
+    REJECTED("Rejected", "Transport is rejected. Equivalent to 'MessageError' with 'eb:ErrorList/eb:HighestSeverity'=\"Error\""),
     UNKNOWN("Unknown", "The value is not supported");
 
     companion object {

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/DeliveryState.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/DeliveryState.kt
@@ -1,0 +1,16 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class DeliveryState(val value: String, val description: String) {
+    UNCONFIRMED("Unconfirmed", "Transport is not confirmed"),
+    ACKNOWLEDGED("Acknowledged", "Transport is confirmed. Equivalent to 'Acknowledgement' without severe 'eb:ErrorList/eb:HighestSeverity'"),
+    REJECTED("Rejected", "Transport is rejected. Equivalient to 'MessageError' with 'eb:ErrorList/eb:HighestSeverity'=\"Error\""),
+    UNKNOWN("Unknown", "The value is not supported");
+
+    companion object {
+        fun fromValue(value: String?): DeliveryState =
+            entries.find { it.value.equals(value, ignoreCase = true) } ?: UNKNOWN
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/EbXmlInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/EbXmlInfo.kt
@@ -1,0 +1,20 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EbXmlInfo(
+    val cpaId: String?,
+    val conversationId: String?,
+    val service: String?,
+    val serviceType: String?,
+    val action: String?,
+    val senderRole: String?,
+    val useSenderLevel1HerId: Boolean?,
+    val receiverRole: String?,
+    val applicationName: String?,
+    val applicationVersion: String?,
+    val middlewareName: String?,
+    val middlewareVersion: String?,
+    val compressPayload: Boolean?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/EbXmlInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/EbXmlInfo.kt
@@ -9,7 +9,7 @@ data class EbXmlInfo(
     val service: String? = null,
     val serviceType: String? = null,
     val action: String? = null,
-    val senderRole: String? = null,
+    val role: String? = null,
     val useSenderLevel1HerId: Boolean? = null,
     val receiverRole: String? = null,
     val applicationName: String? = null,

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/EbXmlInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/EbXmlInfo.kt
@@ -4,17 +4,17 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class EbXmlInfo(
-    val cpaId: String?,
-    val conversationId: String?,
-    val service: String?,
-    val serviceType: String?,
-    val action: String?,
-    val senderRole: String?,
-    val useSenderLevel1HerId: Boolean?,
-    val receiverRole: String?,
-    val applicationName: String?,
-    val applicationVersion: String?,
-    val middlewareName: String?,
-    val middlewareVersion: String?,
-    val compressPayload: Boolean?
+    val cpaId: String? = null,
+    val conversationId: String? = null,
+    val service: String? = null,
+    val serviceType: String? = null,
+    val action: String? = null,
+    val senderRole: String? = null,
+    val useSenderLevel1HerId: Boolean? = null,
+    val receiverRole: String? = null,
+    val applicationName: String? = null,
+    val applicationVersion: String? = null,
+    val middlewareName: String? = null,
+    val middlewareVersion: String? = null,
+    val compressPayload: Boolean? = null
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
@@ -4,9 +4,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ErrorMessage(
-    val error: String?,
+    val error: String? = null,
     val errorCode: Int,
-    val validationErrors: List<String>?,
-    val stackTrace: String?,
+    val validationErrors: List<String>? = null,
+    val stackTrace: String? = null,
     val requestId: String
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
@@ -1,0 +1,9 @@
+package no.nav.emottak.utils.edi2.models
+
+data class ErrorMessage(
+    val error: String?,
+    val errorCode: Int,
+    val validationErrors: List<String>?,
+    val stackTrace: String?,
+    val requestId: String
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
@@ -1,5 +1,8 @@
 package no.nav.emottak.utils.edi2.models
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ErrorMessage(
     val error: String?,
     val errorCode: Int,

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/ErrorMessage.kt
@@ -1,12 +1,22 @@
 package no.nav.emottak.utils.edi2.models
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ErrorMessage(
+    @SerialName("Error")
     val error: String? = null,
+
+    @SerialName("ErrorCode")
     val errorCode: Int,
+
+    @SerialName("ValidationErrors")
     val validationErrors: List<String>? = null,
+
+    @SerialName("StackTrace")
     val stackTrace: String? = null,
+
+    @SerialName("RequestId")
     val requestId: String
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetBusinessDocumentResponse.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetBusinessDocumentResponse.kt
@@ -1,5 +1,8 @@
 package no.nav.emottak.utils.edi2.models
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class GetBusinessDocumentResponse(
     val businessDocument: String,
     val contentType: String,

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetBusinessDocumentResponse.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetBusinessDocumentResponse.kt
@@ -1,0 +1,7 @@
+package no.nav.emottak.utils.edi2.models
+
+data class GetBusinessDocumentResponse(
+    val businessDocument: String,
+    val contentType: String,
+    val contentTransferEncoding: String
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetMessagesRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetMessagesRequest.kt
@@ -16,21 +16,21 @@ data class GetMessagesRequest(
 
         if (receiverHerIds.isNotEmpty()) {
             receiverHerIds.forEach {
-                params += "ReceiverHerIds=$it"
+                params += "receiverHerIds=$it"
             }
         }
 
         senderHerId?.let {
-            params += "SenderHerId=$it"
+            params += "senderHerId=$it"
         }
 
         businessDocumentId?.let {
-            params += "BusinessDocumentId=$it"
+            params += "businessDocumentId=$it"
         }
 
-        params += "IncludeMetadata=$includeMetadata"
-        params += "MessagesToFetch=$messagesToFetch"
-        params += "OrderBy=${orderBy.name}"
+        params += "includeMetadata=$includeMetadata"
+        params += "messagesToFetch=$messagesToFetch"
+        params += "orderBy=${orderBy.name}"
 
         return params.joinToString("&")
     }

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetMessagesRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/GetMessagesRequest.kt
@@ -1,0 +1,37 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetMessagesRequest(
+    val receiverHerIds: List<Int>,
+    val senderHerId: Int? = null,
+    val businessDocumentId: String? = null,
+    val includeMetadata: Boolean = false,
+    val messagesToFetch: Int = 10,
+    val orderBy: OrderBy = OrderBy.ASC
+) {
+    fun toUrlParams(): String {
+        val params = mutableListOf<String>()
+
+        if (receiverHerIds.isNotEmpty()) {
+            receiverHerIds.forEach {
+                params += "ReceiverHerIds=$it"
+            }
+        }
+
+        senderHerId?.let {
+            params += "SenderHerId=$it"
+        }
+
+        businessDocumentId?.let {
+            params += "BusinessDocumentId=$it"
+        }
+
+        params += "IncludeMetadata=$includeMetadata"
+        params += "MessagesToFetch=$messagesToFetch"
+        params += "OrderBy=${orderBy.name}"
+
+        return params.joinToString("&")
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/Message.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/Message.kt
@@ -9,12 +9,12 @@ import kotlin.uuid.Uuid
 @Serializable
 data class Message(
     @Serializable(with = UuidSerializer::class)
-    val id: Uuid?,
-    val contentType: String?,
-    val receiverHerId: Int?,
-    val senderHerId: Int?,
-    val businessDocumentId: String?,
+    val id: Uuid? = null,
+    val contentType: String? = null,
+    val receiverHerId: Int? = null,
+    val senderHerId: Int? = null,
+    val businessDocumentId: String? = null,
     @Serializable(with = InstantSerializer::class)
-    val businessDocumentGenDate: Instant?,
-    val isAppRec: Boolean?
+    val businessDocumentGenDate: Instant? = null,
+    val isAppRec: Boolean? = null
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/Message.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/Message.kt
@@ -1,0 +1,20 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+import no.nav.emottak.utils.serialization.InstantSerializer
+import no.nav.emottak.utils.serialization.UuidSerializer
+import java.time.Instant
+import kotlin.uuid.Uuid
+
+@Serializable
+data class Message(
+    @Serializable(with = UuidSerializer::class)
+    val id: Uuid?,
+    val contentType: String?,
+    val receiverHerId: Int?,
+    val senderHerId: Int?,
+    val businessDocumentId: String?,
+    @Serializable(with = InstantSerializer::class)
+    val businessDocumentGenDate: Instant?,
+    val isAppRec: Boolean?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/OrderBy.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/OrderBy.kt
@@ -1,14 +1,41 @@
 package no.nav.emottak.utils.edi2.models
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Serializable
-enum class OrderBy(val value: Int, description: String) {
-    ASC(1, "Ascending"),
-    DESC(2, "Descending");
+@Serializable(with = OrderBySerializer::class)
+enum class OrderBy(val value: String) {
+    ASC("Ascending"),
+    DESC("Descending");
 
     companion object {
         fun fromValue(value: String?): OrderBy =
-            entries.find { it.value == value?.toIntOrNull() } ?: ASC
+            entries.find { it.value == value } ?: ASC
+    }
+}
+
+object OrderBySerializer : KSerializer<OrderBy> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("OrderBy", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: OrderBy) {
+        val code = when (value) {
+            OrderBy.ASC -> "1"
+            OrderBy.DESC -> "2"
+        }
+        encoder.encodeString(code)
+    }
+
+    override fun deserialize(decoder: Decoder): OrderBy {
+        return when (decoder.decodeString()) {
+            "1" -> OrderBy.ASC
+            "2" -> OrderBy.DESC
+            else -> OrderBy.ASC
+        }
     }
 }

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/OrderBy.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/OrderBy.kt
@@ -1,0 +1,14 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class OrderBy(val value: Int, description: String) {
+    ASC(1, "Ascending"),
+    DESC(2, "Descending");
+
+    companion object {
+        fun fromValue(value: String?): OrderBy =
+            entries.find { it.value == value?.toIntOrNull() } ?: ASC
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostAppRecRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostAppRecRequest.kt
@@ -1,0 +1,10 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostAppRecRequest(
+    val appRecStatus: AppRecStatus,
+    val appRecErrorList: List<AppRecError>?,
+    val ebXmlOverrides: EbXmlInfo?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostAppRecRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostAppRecRequest.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PostAppRecRequest(
     val appRecStatus: AppRecStatus,
-    val appRecErrorList: List<AppRecError>?,
-    val ebXmlOverrides: EbXmlInfo?
+    val appRecErrorList: List<AppRecError>? = null,
+    val ebXmlOverrides: EbXmlInfo? = null
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostMessageRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostMessageRequest.kt
@@ -8,5 +8,5 @@ data class PostMessageRequest(
     val contentType: String,
     val contentTransferEncoding: String,
     val ebXmlOverrides: EbXmlInfo,
-    val receiverHerIdsSubset: List<Int>?
+    val receiverHerIdsSubset: List<Int>? = null
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostMessageRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostMessageRequest.kt
@@ -1,0 +1,11 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostMessageRequest(
+    val businessDocument: String,
+    val contentType: String,
+    val ebXmlOverrides: EbXmlInfo,
+    val receiverHerIdsSubset: List<Int>?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostMessageRequest.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/PostMessageRequest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class PostMessageRequest(
     val businessDocument: String,
     val contentType: String,
+    val contentTransferEncoding: String,
     val ebXmlOverrides: EbXmlInfo,
     val receiverHerIdsSubset: List<Int>?
 )

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/StatusInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/StatusInfo.kt
@@ -1,0 +1,10 @@
+package no.nav.emottak.utils.edi2.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StatusInfo(
+    val receiverHerId: Int,
+    val transportDeliveryState: DeliveryState,
+    val appRecStatus: AppRecStatus?
+)

--- a/src/main/kotlin/no/nav/emottak/utils/edi2/models/StatusInfo.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/edi2/models/StatusInfo.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 data class StatusInfo(
     val receiverHerId: Int,
     val transportDeliveryState: DeliveryState,
-    val appRecStatus: AppRecStatus?
+    val appRecStatus: AppRecStatus? = null
 )


### PR DESCRIPTION
1. Opprettet modeller for EDI Adapter API.
2. Opprettet gjenbrukbar HTTP klient for EDI Adapter.
3. Lagt til Azure Autentisering.

Oppgaver: 
https://github.com/navikt/team-emottak-docs/issues/261
https://github.com/navikt/team-emottak-docs/issues/274