### PR TITLE
Nye hendelsestyper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.5"
+            version = "0.3.6"
             from(components["java"])
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
 
         create("testLibs") {
             version("kotest", "5.9.1")
-            version("testcontainers", "1.18.1")
+            version("testcontainers", "1.21.4")
             version("kotest-extensions", "2.0.2")
             version("turbine", "1.2.0")
 

--- a/src/main/kotlin/no/nav/emottak/utils/common/InstantUtils.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/common/InstantUtils.kt
@@ -1,0 +1,13 @@
+package no.nav.emottak.utils.common
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+const val ZONE_ID_OSLO = "Europe/Oslo"
+
+fun Instant.toOsloZone(): ZonedDateTime = atZone(zoneOslo())
+
+fun nowOsloToInstant(): Instant = ZonedDateTime.now(zoneOslo()).toInstant()
+
+fun zoneOslo(): ZoneId = ZoneId.of(ZONE_ID_OSLO)

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetail.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/EbmsMessageDetail.kt
@@ -1,11 +1,10 @@
 package no.nav.emottak.utils.kafka.model
 
 import kotlinx.serialization.Serializable
+import no.nav.emottak.utils.common.nowOsloToInstant
 import no.nav.emottak.utils.serialization.InstantSerializer
 import no.nav.emottak.utils.serialization.UuidSerializer
 import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 
@@ -26,9 +25,7 @@ data class EbmsMessageDetail(
     @Serializable(with = InstantSerializer::class)
     val sentAt: Instant? = null,
     @Serializable(with = InstantSerializer::class)
-    val savedAt: Instant = ZonedDateTime
-        .now(ZoneId.of("Europe/Oslo"))
-        .toInstant()
+    val savedAt: Instant = nowOsloToInstant()
         .truncatedTo(ChronoUnit.MICROS)
 ) {
     fun toByteArray(): ByteArray {

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
@@ -19,7 +19,8 @@ data class Event(
     val eventData: String = "{}",
     @Serializable(with = InstantSerializer::class)
     val createdAt: Instant = nowOsloToInstant()
-        .truncatedTo(ChronoUnit.MICROS)
+        .truncatedTo(ChronoUnit.MICROS),
+    val conversationId: String? = null
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
@@ -2,11 +2,10 @@ package no.nav.emottak.utils.kafka.model
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import no.nav.emottak.utils.common.nowOsloToInstant
 import no.nav.emottak.utils.serialization.InstantSerializer
 import no.nav.emottak.utils.serialization.UuidSerializer
 import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 
@@ -19,10 +18,9 @@ data class Event(
     val messageId: String,
     val eventData: String = "{}",
     @Serializable(with = InstantSerializer::class)
-    val createdAt: Instant = ZonedDateTime
-        .now(ZoneId.of("Europe/Oslo"))
-        .toInstant()
-        .truncatedTo(ChronoUnit.MICROS)
+    val createdAt: Instant = nowOsloToInstant()
+        .truncatedTo(ChronoUnit.MICROS),
+    val conversationId: String? = null
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/Event.kt
@@ -19,8 +19,7 @@ data class Event(
     val eventData: String = "{}",
     @Serializable(with = InstantSerializer::class)
     val createdAt: Instant = nowOsloToInstant()
-        .truncatedTo(ChronoUnit.MICROS),
-    val conversationId: String? = null
+        .truncatedTo(ChronoUnit.MICROS)
 ) {
     fun toByteArray(): ByteArray {
         return jsonWithDefaults.encodeToString(this).toByteArray()

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/model/EventType.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/model/EventType.kt
@@ -42,7 +42,9 @@ enum class EventType(val value: Int, val description: String) {
     MESSAGE_VALIDATED_AGAINST_XSD(39, "Melding validert mot XSD"),
     VALIDATION_AGAINST_XSD_FAILED(40, "Validering mot XSD mislykket"),
     UNKNOWN_ERROR_OCCURRED(41, "Ukjent feil oppsto!"),
-    REFERENCE_RETRIEVED(42, "Reference hentet");
+    REFERENCE_RETRIEVED(42, "Reference hentet"),
+    MESSAGEFLOW_COMPLETED(43, "Melding ferdigbehandlet"),
+    RETRY_TRIGGED(44, "Melding rekjøres");
 
     companion object {
         fun fromInt(eventCode: Int): EventType {

--- a/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_
 import org.apache.kafka.clients.admin.AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.testcontainers.kafka.KafkaContainer
+import org.testcontainers.kafka.ConfluentKafkaContainer
 import org.testcontainers.utility.DockerImageName
 import java.util.Properties
 import kotlin.time.Duration.Companion.seconds
@@ -31,10 +31,10 @@ abstract class KafkaSpec(body: KafkaSpec.() -> Unit = {}) : StringSpec() {
     private val kafkaImage: DockerImageName =
         DockerImageName.parse("confluentinc/cp-kafka:7.5.0")
 
-    internal val container: KafkaContainer =
+    internal val container: ConfluentKafkaContainer =
         install(
             ContainerExtension(
-                KafkaContainer(kafkaImage)
+                ConfluentKafkaContainer(kafkaImage)
                     .withExposedPorts(9092, 9093)
                     .withNetworkAliases("broker")
                     .withEnv("KAFKA_HOST_NAME", "broker")

--- a/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
@@ -44,7 +44,7 @@ abstract class KafkaSpec(body: KafkaSpec.() -> Unit = {}) : StringSpec() {
                         "KAFKA_TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS",
                         transactionTimeoutInterval.inWholeMilliseconds.toString()
                     )
-                    // .withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer")
+                    .withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "org.apache.kafka.metadata.authorizer.StandardAuthorizer") // For KRaft-based clusters
                     .withEnv("KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND", "true")
                     .withReuse(true)
                     .also { container -> container.start() }

--- a/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
@@ -44,7 +44,7 @@ abstract class KafkaSpec(body: KafkaSpec.() -> Unit = {}) : StringSpec() {
                         "KAFKA_TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS",
                         transactionTimeoutInterval.inWholeMilliseconds.toString()
                     )
-                    .withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer")
+                    // .withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer")
                     .withEnv("KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND", "true")
                     .withReuse(true)
                     .also { container -> container.start() }

--- a/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/utils/kafka/KafkaSpec.kt
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_
 import org.apache.kafka.clients.admin.AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 import java.util.Properties
 import kotlin.time.Duration.Companion.seconds
@@ -29,7 +29,7 @@ abstract class KafkaSpec(body: KafkaSpec.() -> Unit = {}) : StringSpec() {
     private val consumerPollingTimeout = 1.seconds
 
     private val kafkaImage: DockerImageName =
-        DockerImageName.parse("confluentinc/cp-kafka:7.4.0")
+        DockerImageName.parse("confluentinc/cp-kafka:7.5.0")
 
     internal val container: KafkaContainer =
         install(

--- a/src/test/kotlin/no/nav/emottak/utils/kafka/client/EventPublisherClientSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/utils/kafka/client/EventPublisherClientSpec.kt
@@ -44,6 +44,10 @@ class EventPublisherClientSpec : KafkaSpec(
             publisher = EventPublisherClient(settings)
         }
 
+        afterSpec {
+            container.close()
+        }
+
         "Publish two messages to Kafka - messages are received" {
             turbineScope {
                 val firstPublishedEvent = randomEvent("Event 1")
@@ -66,9 +70,9 @@ class EventPublisherClientSpec : KafkaSpec(
             }
         }
 
-        "Publish one message to Kafka - message is received" {
+        "Publish one message to Kafka, with conversationId - message is received" {
             turbineScope {
-                val event = randomEvent("Event 3")
+                val event = randomEvent("Event 3", Uuid.random().toString())
                 publisher.publishMessage(testTopic, event.toByteArray())
 
                 val receiver = KafkaReceiver(receiverSettings())
@@ -87,12 +91,13 @@ class EventPublisherClientSpec : KafkaSpec(
     }
 )
 
-private fun randomEvent(eventData: String): Event = Event(
+private fun randomEvent(eventData: String, conversationId: String? = null): Event = Event(
     eventType = EventType.entries.random(),
     requestId = Uuid.random(),
     contentId = "contentId",
     messageId = "messageId",
-    eventData = eventData
+    eventData = eventData,
+    conversationId = conversationId
 )
 
 private fun compareEvents(event: Event, receivedValue: ByteArray) {


### PR DESCRIPTION
For at EventManager enklere skal vite om en meldingsflyt er ferdig, under kjøring, eller har feilet, så er to nye hendelser lagt inn: `Melding ferdigbehandlet` og `Melding rekjøres`.

- Når en melding feiler, så skal MessageDetail'en settes til `Feil`.
- Og når en melding rekjøres, så skal `Melding rekjøres`-hendelsen sendes, slik at status på MessageDetail'en endres fra `Feil` til `Informasjon`.
- Og når en melding er ferdigbehandlet, sender man en `Melding ferdigbehandlet`-hendelse (med mindre forrige hendelse var `Melding sendt via HTTP`, da er også meldingen ferdigbehandlet).

Har samtidig lagt inn `conversationId: String? = null` i Event-objektet slik at man har mulighet til å angi `conversationId` ved en hendelse.

Har også lagt inn en `InstantUtil.kt` med noen gjenbrukbare funksjoner for tid og sone.

Denne PR sees i sammenheng med oppgave https://github.com/navikt/team-emottak-docs/issues/325.