### PR TITLE
Endrer return type for logEvent og logMessageDetails slik at kafka de…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.8"
+            version = "0.3.9"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.9"
+            version = "0.3.8"
             from(components["java"])
         }
     }

--- a/src/main/kotlin/no/nav/emottak/utils/kafka/service/EventLoggingService.kt
+++ b/src/main/kotlin/no/nav/emottak/utils/kafka/service/EventLoggingService.kt
@@ -4,16 +4,19 @@ import no.nav.emottak.utils.config.EventLogging
 import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.model.EbmsMessageDetail
 import no.nav.emottak.utils.kafka.model.Event
-import org.apache.kafka.clients.producer.RecordMetadata
 
 class EventLoggingService(
     private val eventLoggingConfig: EventLogging,
     private val kafkaPublisherClient: EventPublisherClient
 ) {
 
-    suspend fun logEvent(event: Event): Result<RecordMetadata> =
+    suspend fun logEvent(event: Event) {
         kafkaPublisherClient.publishMessage(eventLoggingConfig.eventTopic, event.toByteArray())
+            .getOrThrow()
+    }
 
-    suspend fun logMessageDetails(ebmsMessageDetail: EbmsMessageDetail): Result<RecordMetadata> =
+    suspend fun logMessageDetails(ebmsMessageDetail: EbmsMessageDetail) {
         kafkaPublisherClient.publishMessage(eventLoggingConfig.messageDetailsTopic, ebmsMessageDetail.toByteArray())
+            .getOrThrow()
+    }
 }


### PR DESCRIPTION
…pendencies ikke lekker over i konsumenter av emottak-utils.

I applikasjonene som bruker dette, får vi mange warnings av typen:
```
Cannot access class 'org.apache.kafka.clients.producer.RecordMetadata' in the expression type. 
While it may work, this case indicates a configuration mistake and can lead to avoidable compilation errors, 
so it may be forbidden soon. Check your module classpath for missing or conflicting dependencies
```

For å unngå behovet for å angi dependencies utenfor emottak-utils, fjernes return-typen til funksjonene. Kaster exception av feil, slik at brukere må håndtere feil. Dette gjøres allerede. Nå slukes faktisk visse feil siden `Result` ofte ikke sjekkes, så dette reduserer også det problemet.