### PR TITLE
Dynamisk oppdatering av gradle version basert på github release tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,10 @@ jobs:
     - name: Set release version
       run: |
         RAW="${{ github.event.release.tag_name || github.event.inputs.version }}"
+        if [ -z "$RAW" ]; then
+          echo "Error: No release tag or version input provided. Please provide a version or run from a release tag." >&2
+          exit 1
+        fi
         VERSION="${RAW#v}"
         echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
     - name: Cache Gradle
@@ -41,11 +45,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: x-access-token
-        RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
     - name: Publish emottak-utils
-      run: ./gradlew --stacktrace publish
+      run: ./gradlew --stacktrace publish -Pversion=${{ env.RELEASE_VERSION }}
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: x-access-token
-        RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3 or v1.2.3)"
+        required: false
+        default: ""
 jobs:
   build:
     name: "build"
@@ -17,6 +22,11 @@ jobs:
       with:
         "java-version": "21"
         "distribution": "temurin"
+    - name: Set release version
+      run: |
+        RAW="${{ github.event.release.tag_name || github.event.inputs.version }}"
+        VERSION="${RAW#v}"
+        echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
     - name: Cache Gradle
       uses: actions/cache@v5
       with:
@@ -31,9 +41,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: x-access-token
+        RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
     - name: Publish emottak-utils
       run: ./gradlew --stacktrace publish
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: x-access-token
+        RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,12 +24,12 @@ jobs:
         "distribution": "temurin"
     - name: Set release version
       run: |
-        RAW="${{ github.event.release.tag_name || github.event.inputs.version }}"
-        if [ -z "$RAW" ]; then
-          echo "Error: No release tag or version input provided. Please provide a version or run from a release tag." >&2
+        RAW_VERSION="${{ github.event.release.tag_name || github.event.inputs.version }}"
+        VERSION="${RAW_VERSION#v}"
+        if [ -z "$VERSION" ] || ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$ ]]; then
+          echo "Error: Invalid or missing version '${VERSION}'. Expected format e.g. 1.2.3 or 1.2.3-SNAPSHOT." >&2
           exit 1
         fi
-        VERSION="${RAW#v}"
         echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
     - name: Cache Gradle
       uses: actions/cache@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = (findProperty("version") ?: "0.4.0-SNAPSHOT").toString()
+            version = project.version.toString()
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = "0.3.8"
+            version = System.getenv("RELEASE_VERSION") ?: "0.4.0-SNAPSHOT"
             from(components["java"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.emottak"
             artifactId = "emottak-utils"
-            version = System.getenv("RELEASE_VERSION") ?: "0.4.0-SNAPSHOT"
+            version = (findProperty("version") ?: "0.4.0-SNAPSHOT").toString()
             from(components["java"])
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Overstyres automatisk ved publisering av GitHub Release
+version=0.4.0-SNAPSHOT


### PR DESCRIPTION
Leser `github.event.release.tag_name` når publish trigges, og bruker denne verdien som gradle version. Ikke lenger nødvendig å oppdatere `build.gradle.kts` direkte. Stripper `v` fra GitHub Release tag. Det betyr at både `v0.3.9` og `0.3.9` blir til `0.3.9`. Defaulter til generisk SNAPSHOT-version om ikke angitt.